### PR TITLE
Write functions for libowski input files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Data file with the origen transition matrix text files
 data/
+*.txt
 # swp files
 *.swp
 *-swp

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Data file with the origen transition matrix text files
 data/
+*.dat
 *.txt
 # swp files
 *.swp

--- a/origenTools/pyOrigen.py
+++ b/origenTools/pyOrigen.py
@@ -203,7 +203,20 @@ class ORIGENData:
         lambda_ = data.at[nuclideID,'decay[1/s]']
         return lambda_
 
-    def getReactionRemovalRate(self, nuclideID, flux):
+    def getMolarMass(self, nuclideID):
+        """
+        Gets the molar mass
+
+        @param nuclideID    Nuclide ID based on Origen indexing
+
+        @return mm          Molar mass [g/mol]
+        """
+        assert(len(str(nuclideID))==8)
+        data = self._diagionalPandasData.set_index('nuclide')
+        mm = data.at[nuclideID,'mass[g/mol]']
+        return mm
+
+    def getReactionRemovalRate(self, nuclideID, flux=1.0):
         """
         Gets the reaction removal rate in barns
 
@@ -218,7 +231,8 @@ class ORIGENData:
         rxRate = data.at[nuclideID,'rx[barn]']
         return rxRate*1.e-24*flux
 
-    def getReactionRate(self, parentNuclideID, daughterNuclideID, flux):
+    def getReactionRate(self, parentNuclideID, daughterNuclideID, flux=1.0, decayOnly=False,
+            transOnly=False):
         """
         Gets the reaction rate in barns from parent nuclide
         to daughter nuclide
@@ -226,6 +240,9 @@ class ORIGENData:
         @param parentNuclideID      Parent nuclide ID
         @param daughterNuclideID    Daughter nuclide ID
         @param flux                 Neutron flux in 1/cm^2/s
+        @param decayOnly            Logical set to true if the user only wants decay reactions
+        #param transmuationOnly     Logical set to tru if the user only wants transmutation
+                                    reactions
 
         @return rxRate              Reaction rate from parent nuclide to
                                     daughter nuclide in 1/s
@@ -241,19 +258,33 @@ class ORIGENData:
                 rxn = dfReaction.iloc[rxnIndex]
                 # If the reaction is not decay.
                 if reactionID != -1:
-                    rxnRate += rxn['rx[barn]']*1.e-24*flux
+                    if decayOnly:
+                        rxnRate += 0.0
+                    else:
+                        rxnRate += rxn['rx[barn]']*1.e-24*flux
                 else:
-                    # The reaction is decay
-                    rxnRate += rxn['rx[barn]']
+                    if transOnly:
+                        rxnRate += 0.0
+                    else:
+                        # The reaction is decay
+                        rxnRate += rxn['rx[barn]']
             return rxnRate
         else:
+            rxnRate = 0.0
             # If the reaction is not decay.
             # The parent daughter relation only has one reaction 
             if dfReaction['tid'] != -1:
-                return dfReaction['rx[barn]']*1.e-24*flux
+                if decayOnly:
+                    rxnRate = 0.0
+                else:
+                    rxnRate = dfReaction['rx[barn]']*1.e-24*flux
             else:
                 # The reaction is decay
-                return dfReaction['rx[barn]']
+                if transOnly:
+                    rxnRate = 0.0
+                else:
+                    rxnRate = dfReaction['rx[barn]']
+            return rxnRate
 
     def getReactionDaughters(self, parentNuclideID, tol=0.0):
         """

--- a/origenTools/pyTransition.py
+++ b/origenTools/pyTransition.py
@@ -44,7 +44,7 @@ class transitionMatrix:
         #nuclideDict = self._dataObject.removeRedundentGroupd(nuclideDict)
         self.setProblemNuclides(nuclideDict)
 
-    def setProblemNuclides(self, nuclideDic, removeDublicateGroups=False):
+    def setProblemNuclides(self, nuclideDic, removeDublicateGroups=True):
         """
         Sets the nuclides to be in the transition matrix
 
@@ -59,7 +59,7 @@ class transitionMatrix:
             if massNumbers:
                 for massNumber in massNumbers:
                     IDs = self._dataObject.getNuclideOrigenIDs(atomicNumber, 
-                        massNumber, addG1=False)
+                        massNumber)
                     for ID in IDs:
                         nuclideIDs.append(ID)
             else:
@@ -75,13 +75,28 @@ class transitionMatrix:
         # Need to remove this bullshit
         if removeDublicateGroups:
             uniqueNuclides = []
-            uniqueNuclidesTemp = []
             
-            for nuclide in nuclideIDs:
-                val = int(str(nuclide)[1:])
-                if val not in uniqueNuclidesTemp:
-                    uniqueNuclidesTemp.append(val)
-                    uniqueNuclides.append(nuclide)
+            for thisNuclide in nuclideIDs:
+                thisGroupID = self._dataObject.getSubGroup(thisNuclide)
+                thisVal = int(str(thisNuclide)[1:])
+                candidateNuclide = thisNuclide
+                dublicateFound = False
+                tempDublicateNuclides = []
+                for otherNuclide in nuclideIDs:
+                    if thisNuclide == otherNuclide:
+                        pass
+                    else:
+                        otherGroupID = self._dataObject.getSubGroup(otherNuclide)
+                        otherVal = int(str(otherNuclide)[1:])
+                        if thisVal == otherVal:
+                            dublicateFound = True
+                            tempDublicateNuclides.append(otherNuclide)
+                if not dublicateFound:
+                    uniqueNuclides.append(candidateNuclide)
+                else:
+                    if thisGroupID == 3 and dublicateFound:
+                        uniqueNuclides.append(candidateNuclide)
+
             self._nuclides = np.asarray(uniqueNuclides)
         else:
             self._nuclides = np.asarray(nuclideIDs)

--- a/origenTools/pyTransition.py
+++ b/origenTools/pyTransition.py
@@ -71,7 +71,8 @@ class transitionMatrix:
         # Removes dublicate groups from the nuclide list. This part 
         # is kinda sketchy right now. I haven't looked though the file
         # to check if the reaction rates are the same for a nuclide in 
-        # different sub groups.
+        # different sub groups. 
+        # Need to remove this bullshit
         if removeDublicateGroups:
             uniqueNuclides = []
             uniqueNuclidesTemp = []
@@ -121,6 +122,74 @@ class transitionMatrix:
                     transMatrix[thisIndex, parentIndex] += coeff
 
         return transMatrix
+
+    def writeLibowskiSpeciesInputFile(self, fname):
+        """
+        Writes an input file used to set the species. 
+        Format example:
+            eAName  Mass[lbm/mol]   initial amount[mole]    diffusion coeff[ft^2/s]
+            u-235   235.0439        1.0                     0.0
+
+        @param fname    Name of file to write to
+        """
+        f = open(fname, "w")
+        f.write("Name   Mass[lbm/mol]   initial amount[mole]    diffusion coeff[ft^2/s]\n")
+        for nuclide in self._nuclides:
+            name = self._dataObject.convertIDtoEAmName(nuclide)
+            molarMass = str(self._dataObject.getMolarMass(nuclide))
+            initCon = str(0.0)
+            difCoeff = str(0.0)
+            decayConst = str(self._dataObject.getDecayConstant(nuclide))
+            string = name + '\t' + molarMass + '\t' + initCon + '\t' + difCoeff + '\n'
+            f.write(string)
+        f.close()
+
+    def writeLibowskiSpeciesReactionFile(self, fname, decayOnly=False, transOnly=False):
+        """
+        Writes an input file used to set reaction rates for speices in libowski. In
+        libowski the coefficient used for source terms are housed in a std::vector<double> 
+        of length numOfSpecies.
+
+        When writting this file it is assumed that the speices ID's in libowsk follow the 
+        order that they are from the writeLibowskiSpeciesInputFile function
+        """
+        f = open(fname, "w")
+        # builds the matrix index nuclide map. Not that the index needs to be the same 
+        # integer that is returned from the libowski add species function
+        matrixIndex_nuclide_map = OrderedDict()
+        for index, nuclide in enumerate(self._nuclides):
+            matrixIndex_nuclide_map[nuclide] = index
+        # Loops though nuclides
+        for nuclide in self._nuclides:
+            name = self._dataObject.convertIDtoEAmName(nuclide)
+            coeffVect = np.zeros((1,len(self._nuclides)))
+            # The decay constant 1/s
+            diagCoeff = self._dataObject.getDecayConstant(nuclide) 
+            thisIndex = matrixIndex_nuclide_map[nuclide]
+            if not transOnly:
+                coeffVect[0,thisIndex] += diagCoeff
+
+            # Loops over source terms from neutron induced reactions and
+            # decay. These are the off diagonal elements and will be possitive
+            for parent in self._dataObject.getReactionParents(nuclide):
+                # Loop over parent nuclides
+                if parent in self._nuclides:
+                    parentIndex = matrixIndex_nuclide_map[parent]
+                    # Gets the coefficient. 1/s
+                    coeff = self._dataObject.getReactionRate(parent, nuclide, 
+                        decayOnly=decayOnly, transOnly=transOnly)
+                    # Sets the coefficient
+                    coeffVect[0,parentIndex] += coeff
+            # the line string to write to the file
+            string = str(thisIndex) + '\t' + name + '\t'
+            # adds the coefficent to the string
+            for coeff in coeffVect.tolist():
+                string += str(coeff) + '\t'
+            string += '\n' 
+            f.write(string)
+        f.close()
+
+               
 
     def getNuclides(self):
         """

--- a/origenTools/pyTransition.py
+++ b/origenTools/pyTransition.py
@@ -133,7 +133,6 @@ class transitionMatrix:
         @param fname    Name of file to write to
         """
         f = open(fname, "w")
-        f.write("Name   Mass[lbm/mol]   initial amount[mole]    diffusion coeff[ft^2/s]\n")
         for nuclide in self._nuclides:
             name = self._dataObject.convertIDtoEAmName(nuclide)
             molarMass = str(self._dataObject.getMolarMass(nuclide))
@@ -167,7 +166,7 @@ class transitionMatrix:
             diagCoeff = self._dataObject.getDecayConstant(nuclide) 
             thisIndex = matrixIndex_nuclide_map[nuclide]
             if not transOnly:
-                coeffVect[0,thisIndex] += diagCoeff
+                coeffVect[0,thisIndex] += -diagCoeff
 
             # Loops over source terms from neutron induced reactions and
             # decay. These are the off diagonal elements and will be possitive
@@ -183,8 +182,9 @@ class transitionMatrix:
             # the line string to write to the file
             string = str(thisIndex) + '\t' + name + '\t'
             # adds the coefficent to the string
-            for coeff in coeffVect.tolist():
-                string += str(coeff) + '\t'
+            for index in range(coeffVect.shape[1]):
+                coeff = coeffVect[0,index]
+                string += np.str(coeff) + '\t'
             string += '\n' 
             f.write(string)
         f.close()

--- a/pyLibowski.py
+++ b/pyLibowski.py
@@ -3,6 +3,7 @@ from matexp.CRAM import apply
 import numpy as np
 import numpy.linalg as LA
 import matplotlib.pyplot as plt
+import sys
 from collections import OrderedDict
 
 def unpackSolution(transObj, solDic, sol):
@@ -26,7 +27,7 @@ def unpackSolution(transObj, solDic, sol):
 diagDecayFile = "origenTools/data/diag-dec.txt"
 diagRxFile = "origenTools/data/diag-rx.txt"
 offDiagRxFile = "origenTools/data/offdiag.txt"
-nuclideNames = "origenTools/data/baseCaseOrigen.txt"
+nuclideNames = sys.argv[1]
 
 # Transition matrix object
 transition = transitionMatrix(diagDecayFile, diagRxFile, offDiagRxFile)

--- a/pyLibowski.py
+++ b/pyLibowski.py
@@ -36,8 +36,8 @@ nuclideDict = {'U': [235],
                'I': [135]
                 }
 # Set the nuclides
-transition.setProblemNuclides(nuclideDict)
-#transition.setProblemNuclidesFromFile(nuclideNames)
+#transition.setProblemNuclides(nuclideDict)
+transition.setProblemNuclidesFromFile(nuclideNames)
 nuclides = transition.getNuclides()
 n0 = np.zeros((len(nuclides), 1))
 #n0[:] = 1e20
@@ -59,10 +59,13 @@ flux = 1.e13
 # builds the transition matrix
 #matrix = transition.buildTransitionMatrix(flux)
 
-transition.writeLibowskiSpeciesInputFile("speciesInputNamesSmall.txt")
-transition.writeLibowskiSpeciesReactionFile("speciesInputDecaySmall.txt", decayOnly=True)
-transition.writeLibowskiSpeciesReactionFile("speciesInputTransSmall.txt", transOnly=True)
+transition.writeLibowskiSpeciesInputFile("speciesInputNames.dat")
+transition.writeLibowskiSpeciesReactionFile("speciesInputDecay.dat", decayOnly=True)
+transition.writeLibowskiSpeciesReactionFile("speciesInputTrans.dat", transOnly=True)
 
+#transition.writeLibowskiSpeciesInputFile("speciesInputNamesSmall.txt")
+#transition.writeLibowskiSpeciesReactionFile("speciesInputDecaySmall.txt", decayOnly=True)
+#transition.writeLibowskiSpeciesReactionFile("speciesInputTransSmall.txt", transOnly=True)
 
 """
 plt.spy(matrix)

--- a/pyLibowski.py
+++ b/pyLibowski.py
@@ -36,8 +36,8 @@ nuclideDict = {'U': [235],
                'I': [135]
                 }
 # Set the nuclides
-#transition.setProblemNuclides(nuclideDict)
-transition.setProblemNuclidesFromFile(nuclideNames)
+transition.setProblemNuclides(nuclideDict)
+#transition.setProblemNuclidesFromFile(nuclideNames)
 nuclides = transition.getNuclides()
 n0 = np.zeros((len(nuclides), 1))
 #n0[:] = 1e20
@@ -57,8 +57,14 @@ solDic = OrderedDict()
 # neutron flux
 flux = 1.e13
 # builds the transition matrix
-matrix = transition.buildTransitionMatrix(flux)
-print(matrix)
+#matrix = transition.buildTransitionMatrix(flux)
+
+transition.writeLibowskiSpeciesInputFile("speciesInputNamesSmall.txt")
+transition.writeLibowskiSpeciesReactionFile("speciesInputDecaySmall.txt", decayOnly=True)
+transition.writeLibowskiSpeciesReactionFile("speciesInputTransSmall.txt", transOnly=True)
+
+
+"""
 plt.spy(matrix)
 plt.show()
 
@@ -83,3 +89,4 @@ plt.xlabel("Time [day]")
 plt.ylabel("Atomic number density")
 plt.yscale("log")
 plt.show()
+"""


### PR DESCRIPTION
Added functions to write species input files to libowski to do large depletion calculations. This includes functions to write 3 files, speciesNames.dat, speciesDecay.dat and speciesTrans.dat. SpeciesNames writes out a file that libowski uses to add the species to the system, this includes species isomeric names, initial concentration and molar mass. SpeciesDecay has the species integer ID, species isomeric name and a row of decay constants that are source terms from each of the other species in the system [1/s]. SpeciesTrans has the same format as speciesDecay but withe the transmutation coefficients for each species [cm^2]. These terms need to be multiplied by the neutron flux [1/cm^2/s]. Separating them out like this allows me to scale the transmutation source term with the neutron flux.